### PR TITLE
Bugfix/#16/unexpectedlly reset targets

### DIFF
--- a/times-hub-front/Makefile
+++ b/times-hub-front/Makefile
@@ -1,4 +1,8 @@
 
+.PHONY: build
+build:
+	npm run build
+
 .PHONY: run
 run:
 	npm run start

--- a/times-hub-front/package-lock.json
+++ b/times-hub-front/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "@types/clone": "^2.1.1",
         "@types/jest": "^27.5.2",
         "@types/node": "^16.18.24",
         "@types/react": "^18.0.38",
@@ -3843,6 +3844,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg=="
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",

--- a/times-hub-front/package-lock.json
+++ b/times-hub-front/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "^16.18.24",
         "@types/react": "^18.0.38",
         "@types/react-dom": "^18.0.11",
+        "clone": "^2.1.2",
         "modern-css-reset": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -5597,6 +5598,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {

--- a/times-hub-front/package.json
+++ b/times-hub-front/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^16.18.24",
     "@types/react": "^18.0.38",
     "@types/react-dom": "^18.0.11",
+    "clone": "^2.1.2",
     "modern-css-reset": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/times-hub-front/package.json
+++ b/times-hub-front/package.json
@@ -10,6 +10,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "@types/clone": "^2.1.1",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.24",
     "@types/react": "^18.0.38",

--- a/times-hub-front/src/App.tsx
+++ b/times-hub-front/src/App.tsx
@@ -31,24 +31,14 @@ const WorkspaceApp: React.FC = () => {
   }
 
   const onChecked = async (ws: Workspace) => {
-    toggleChecked(ws.id)
-
     setWorkspaces(
-      workspaces.map((workspace) => {
-        if (workspace.id === ws.id) {
-          return { ...workspace, checked: !workspace.checked }
+      workspaces.map((w) => {
+        if (w.id === ws.id) {
+          return { ...w, checked: !w.checked }
         }
-        return workspace
+        return w
       })
     )
-  }
-
-  const toggleChecked = (id: number) => {
-    if (checkedIDs.has(id)) {
-      checkedIDs.delete(id)
-    } else {
-      checkedIDs.add(id)
-    }
   }
 
   const onDelete = async (id: number) => {
@@ -57,7 +47,15 @@ const WorkspaceApp: React.FC = () => {
     throw new Error("Not implemented")
   }
 
-  const onMessageSubmit = async (msg: MessagePayload) => {
+  const onMessageSubmit = async (text: string) => {
+    const checkedIDs: Set<number> = new Set()
+    // workspace.checked が true の場合は、checkedIDs に workspace.id を追加する
+    workspaces.map((w) => w.checked && checkedIDs.add(w.id))
+
+    const msg: MessagePayload = {
+      targets: Array.from(checkedIDs),
+      text
+    }
     sendMessage(msg)
   }
 
@@ -99,7 +97,7 @@ const WorkspaceApp: React.FC = () => {
           <Typography variant="h2">Message</Typography>
           <Stack spacing={2}>
             {/* <Typography>{checkedIDs}</Typography> */}
-            <MessageForm checkedIDs={checkedIDs} onSubmit={onMessageSubmit}></MessageForm>
+            <MessageForm onSubmit={onMessageSubmit}></MessageForm>
           </Stack>
         </Stack>
       </Box>

--- a/times-hub-front/src/components/MessageForm.tsx
+++ b/times-hub-front/src/components/MessageForm.tsx
@@ -1,22 +1,16 @@
 import { Button, Grid, TextField, Paper, Box } from "@mui/material"
 import React from "react"
-import { MessagePayload } from "../types/message"
 
 
 type Props = {
-  checkedIDs: Set<number>
-  onSubmit: (msg: MessagePayload) => void
+  onSubmit: (text: string) => void
 }
 
-const MessageItem: React.FC<Props> = ({ checkedIDs, onSubmit }) => {
+const MessageItem: React.FC<Props> = ({ onSubmit }) => {
   const [editText, setEditText] = React.useState("")
 
   const submitHandler = () => {
-    const msg: MessagePayload = {
-      targets: Array.from(checkedIDs.values()),
-      text: editText
-    }
-    onSubmit(msg)
+    onSubmit(editText)
     setEditText("")
   }
 

--- a/times-hub-front/src/components/WorkspaceEditFormDialog.tsx
+++ b/times-hub-front/src/components/WorkspaceEditFormDialog.tsx
@@ -95,6 +95,7 @@ const WorkspaceEditFormDialog: React.FC<Props> = ({
 
   const editWorkspaceHandler = async () => {
     onSubmit({
+      ...ws,
       id: ws.id, // not change
       name: wsName === "" ? ws.name : wsName,
       ws_type: wsType === "" ? ws.ws_type : wsType,

--- a/times-hub-front/src/lib/api/workspace.ts
+++ b/times-hub-front/src/lib/api/workspace.ts
@@ -4,6 +4,7 @@ import type {
   Workspace,
   WorkspaceApiResponse
 } from "../../types/workspace"
+import { getWorkspaceDefaultValue } from "../../types/workspaceDefault"
 
 // TODO: fix hard code url
 const db_url_base = "http://localhost:3000"
@@ -21,10 +22,10 @@ export const addWorkspaceItem = async (payload: WorkspacePayload) => {
   }
   const json: WorkspaceApiResponse = await res.json()
   const ws: Workspace = {
+    ...getWorkspaceDefaultValue(),
     id: json.id,
     name: json.name,
-    ws_type: json.ws_type,
-    checked: false
+    ws_type: json.ws_type
   }
   return ws
 }
@@ -42,10 +43,10 @@ export const getWorkspaceItems = async () => {
   const json: WorkspaceApiResponse[] = await res.json()
   const ws_array: Workspace[] = json.map((ws) => {
     return {
+      ...getWorkspaceDefaultValue(),
       id: ws.id,
       name: ws.name,
-      ws_type: ws.ws_type,
-      checked: false
+      ws_type: ws.ws_type
     }
   })
 
@@ -72,10 +73,10 @@ export const updateWorkspaceItem = async (ws: UpdateWorkspacePayload) => {
   }
   const json: WorkspaceApiResponse = await res.json()
   const ws_res: Workspace = {
+    ...getWorkspaceDefaultValue(),
     id: json.id,
     name: json.name,
-    ws_type: json.ws_type,
-    checked: false
+    ws_type: json.ws_type
   }
   return ws_res
 }

--- a/times-hub-front/src/types/workspace.d.ts
+++ b/times-hub-front/src/types/workspace.d.ts
@@ -6,6 +6,16 @@ export type Workspace = {
   checked: boolean
 }
 
+type SubsetKeysOf<T> = { [P in keyof T]?: T[P] }
+
+export type WorkspaceDefault = SubsetKeysOf<Workspace> & {
+  checked: boolean
+}
+
+export const WorkspaceDefaultValue: WorkspaceDefault = {
+  checked: false
+}
+
 export type WorkspaceApiResponse = {
   id: number
   name: string

--- a/times-hub-front/src/types/workspaceDefault.ts
+++ b/times-hub-front/src/types/workspaceDefault.ts
@@ -1,0 +1,11 @@
+import clone from "clone"
+import type { WorkspaceDefault } from "./workspace"
+
+
+const workspaceDefaultValue: WorkspaceDefault = {
+  checked: false
+}
+
+export const getWorkspaceDefaultValue = () => {
+  return clone(workspaceDefaultValue)
+}


### PR DESCRIPTION
close #16 

- check の状態は workspace と動機させた
- workspaceの編集を行ったあとは workspaces が改めて取得されるため, default 値の `checked: false` が使われる
- つまり、ワークスペースを作ったり編集するたびに checkbox のチェックは外れる
